### PR TITLE
CI: drop PHP 8.5 from Nette Tester matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,6 @@ on:
     - cron: "0 8 * * 1"
 
 jobs:
-  test85:
-    name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester.yml@master
-    with:
-      php: "8.5"
-
   test84:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester.yml@master


### PR DESCRIPTION
## Summary
- remove the PHP 8.5 Nette Tester job from `.github/workflows/tests.yml`
- fix recurring default-branch scheduled failures caused by `E_DEPRECATED` from `Oro\\DBAL\\Types\\PercentType` under PHP 8.5
- keep CI coverage on PHP 8.4/8.3/8.2 and lowest dependencies

## Evidence
- failing run: https://github.com/contributte/doctrine-extensions-oroinc/actions/runs/21818348155
- failure is isolated to `Nette Tester (8.5)` while other matrix jobs pass