### PR TITLE
Build: run coverage with php

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

- replace `-p phpdbg` with `-p php` in the `coverage` target of `Makefile`
- align this repository with contributte/contributte#73 so coverage runs no longer depend on PHPDBG

## Motivation

Coverage targets across Contributte are being migrated away from PHPDBG. This keeps the local `Makefile` consistent with that org-wide change.

## Changes

- update both `coverage` target variants to invoke Tester with `php`

## Testing

- [x] `composer install`
- [ ] `make coverage` *(blocked locally: PHP has no Xdebug/PCOV extension and coverage with `php` requires one of them)*
- [ ] CI passes