### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.2"


### PR DESCRIPTION
## What changed
- Added secrets: inherit to .github/workflows/coverage.yml so the reusable coverage workflow receives repository secrets from the caller.

## Why
- The reusable coverage workflow needs inherited secrets to access the tokens it depends on during coverage runs.
- Relates to contributte/contributte#74.